### PR TITLE
mqtt: export values as single topics as well

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -42,6 +42,8 @@ mqttport=1883
 mqttfields=pregard,psurplus,p1regard,p2regard,p3regard,p1surplus,p2surplus,p3surplus
 #topic will be exted3ed with serial
 mqtttopic=SMA-EM/status
+# publish all values as single topics (0 or 1)
+publish_single=1
 # How frequently to send updates over (defaults to 20 sec)
 min_update=30
 #debug output

--- a/contributors.md
+++ b/contributors.md
@@ -22,3 +22,7 @@ SMA-EM-Daemon contributors
   * "remotedebug" to allow remote debug from PyCharm
   * "influxdb" and sample grafana dashboard based on this plugin
   * "symcon" to supply SMA EM/HOM and PV data to "IP-Symcon" 
+
+* **[david-m-m](https://github.com/david-m-m)**
+
+  * enhance mqtt module to export topics for all metrics, works with [mqtt_exporter](https://github.com/bendikwa/mqtt_exporter)

--- a/features/mqtt.py
+++ b/features/mqtt.py
@@ -2,6 +2,7 @@
     Send SMA values to mqtt broker.
 
     2018-12-23 Tommi2Day
+    2019-03-02 david-m-m
 
     Configuration:
 
@@ -17,6 +18,9 @@
     mqttfields=pregard,psurplus,p1regard,p2regard,p3regard,p1surplus,p2surplus,p3surplus
     #topic will be exted3ed with serial
     mqtttopic=SMA-EM/status
+
+    # publish all values additionally as single topics (0 or 1)
+    publish_single=1
 
     # How frequently to send updates over (defaults to 20 sec)
     min_update=5
@@ -53,6 +57,7 @@ def run(emparts,config):
     mqttpass = config.get('mqttpass', None)
     mqtttopic = config.get('mqtttopic',"SMA-EM/status")
     mqttfields = config.get('mqttfields', 'pregard,psurplus')
+    publish_single = int(config.get('publish_single',0))
 
     # mqtt client settings
     myhostname = platform.node()
@@ -94,6 +99,13 @@ def run(emparts,config):
             client.connect(str(mqtthost), int(mqttport))
             client.on_publish = on_publish
             client.publish(topic, payload)
+            # publish each value as separate topic
+            if publish_single == 1:
+                for item in data.keys():
+                    itemtopic=topic+'/'+item
+                    if mqtt_debug > 0:
+                        print("mqtt: publishing %s:%s" % (itemtopic,data[item]) )
+                    client.publish(itemtopic,str(data[item]))
             if mqtt_debug > 0:
                 print("mqtt: sma-em data published %s:%s" % (
                     format(time.strftime("%H:%M:%S", time.localtime(mqtt_last_update))),payload))
@@ -121,6 +133,7 @@ def stopping(emparts,config):
     pass
 
 def on_publish(client,userdata,result):
+    time.sleep(0.01) # experimental value, seems to work...
     pass
 
 def config(config):


### PR DESCRIPTION
Hi,
while trying to scrape data with prometheus from mqtt I noticed that publishing each measurement in a separate topic is very helpful.
This way scraping with mqtt_exporter is relatively easy. (Although not yet optimal. But that would require a heavy re-design...)
I hope you find this helpful.
Greetings, David