### PR TITLE
added support for influxdb TLS

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -77,6 +77,7 @@ debug=1
 # influx
 host=influxdb
 port=8086
+ssl=false
 db=SMA
 
 timeout=5

--- a/features/influxdb.py
+++ b/features/influxdb.py
@@ -61,6 +61,7 @@ def run(emparts,config):
     db = config.get('db', 'SMA')
     host = config.get('host', 'influxdb')
     port = int(config.get('port', 8086))
+    ssl = bool(config.get('ssl', 'false'))
     timeout = int(config.get('timeout', 5))
     user = config.get('user', None)
     password = config.get('password',None )
@@ -70,7 +71,7 @@ def run(emparts,config):
     influx=None
     #connect to db, create one if needed
     try:
-        influx = InfluxDBClient(host=host, port=port, username=user, password=password,timeout=timeout)
+        influx = InfluxDBClient(host=host, port=port, ssl=ssl, username=user, password=password, timeout=timeout)
         dbs = influx.get_list_database()
         if influx_debug>1:
             print(dbs)

--- a/features/influxdb.py
+++ b/features/influxdb.py
@@ -71,7 +71,7 @@ def run(emparts,config):
     influx=None
     #connect to db, create one if needed
     try:
-        influx = InfluxDBClient(host=host, port=port, ssl=ssl, username=user, password=password, timeout=timeout)
+        influx = InfluxDBClient(host=host, port=port, ssl=ssl, verify_ssl=ssl, username=user, password=password, timeout=timeout)
         dbs = influx.get_list_database()
         if influx_debug>1:
             print(dbs)


### PR DESCRIPTION
The InfluxDB feature failed quietly when trying to connect to my instance because I require a TLS secured connection. I added support for this in the sample config and in the feature module.