### PR TITLE
fix pydevd package naming

### DIFF
--- a/features/remotedebug.py
+++ b/features/remotedebug.py
@@ -1,7 +1,7 @@
 """
     Allow remote debug with PyCharm
 
-    2018-12-23 Tommi2Day
+    2020-09-20 Tommi2Day
 
     [FEATURE-debug]
     # Debug settings
@@ -9,22 +9,27 @@
     debugport=9100
 
 """
-import pydevd
+import pydevd_pycharm
 
-def run(emparts,config):
+
+def run(emparts, config):
     pass
-def stopping(emparts,config):
+
+
+def stopping(emparts, config):
     pass
+
+
 def config(config):
     # prepare mqtt settings
     print('debug feature enabled')
     debughost = config.get('debughost', None)
     debugport = config.get('debugport', None)
-    if None not in (debughost,debugport):
+    if None not in (debughost, debugport):
         try:
-            print('activate debug for '+debughost+' Port '+str(debugport))
-            pydevd.settrace(debughost, port=int(debugport), stdoutToServer=True, stderrToServer=True)
+            print('activate debug for ' + debughost + ' Port ' + str(debugport))
+            pydevd_pycharm.settrace(debughost, port=int(debugport), stdoutToServer=True, stderrToServer=True)
         except Exception as e:
-            print( '...failed')
+            print('...failed')
             print(e)
             pass


### PR DESCRIPTION
this small fix for feature remote debug reflects the renamed pydevd to pydevd-pycharm and does some code formatting