### PR TITLE
improve the feature init

### DIFF
--- a/daemon3x.py
+++ b/daemon3x.py
@@ -81,6 +81,7 @@ class daemon3x:
 		
 		# Start the daemon
 		self.daemonize()
+		self.config()
 		self.run()
 
 	def stop(self):
@@ -123,4 +124,7 @@ class daemon3x:
 		
 		It will be called after the process has been daemonized by 
 		start() or restart()."""
+		
+	def config(self):
+		"""overwritten in subclass"""
 


### PR DESCRIPTION
When the double fork of the daemon3x class is used, the feature plugins are initialized three times. This looks strange, when reading the log files.

I created a function daemon3x.config to init the features just once in the forked daemon. I also merged the changes from #46, which are also improving the startup.