### PR TITLE
fix InfluxDB type errors

### DIFF
--- a/features/influxdb.py
+++ b/features/influxdb.py
@@ -218,7 +218,7 @@ def run(emparts, config):
                 inv.pop(t)
 
             for f in pvfields.split(','):
-                fields[f] = inv.get(f, 0)
+                fields[f] = inv.get(f)
 
             datapoint['tags'] = tags.copy()
             datapoint['fields'] = fields.copy()


### PR DESCRIPTION
We probably don't need this default value of 0 and let it default to None if no value can be queried. In fact, this can lead to InfluxDB type errors if the first inverter queried returns no value for a float field.

Additional testing appreciated.